### PR TITLE
Interface separation

### DIFF
--- a/source/core/engine/include/core/ConfigurationManager.hpp
+++ b/source/core/engine/include/core/ConfigurationManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <defs/Log.hpp>
 #include <defs/MdsInterface.hpp>
+#include <defs/Configuration.hpp>
 #include <core/MeasurementObjectFactory.hpp>
 
 /*!

--- a/source/core/engine/include/core/DistributionManager.hpp
+++ b/source/core/engine/include/core/DistributionManager.hpp
@@ -4,8 +4,9 @@
 
 #include <defs/Log.hpp>
 #include <defs/MdsInterface.hpp>
-#include <defs/MiniObjectDefs.hpp>
+#include <defs/MeasurementObjectDefs.hpp>
 #include <defs/Distribution.hpp>
+#include <defs/Receiver.hpp>
 #include <statistics/DistributionStatistics.hpp>
 
 /*!

--- a/source/core/engine/source/ConfigurationManager.cxx
+++ b/source/core/engine/source/ConfigurationManager.cxx
@@ -2,6 +2,7 @@
 #include <XmlWrapper.hpp>
 #include <algorithm>
 #include <core/DistributionManager.hpp>
+#include <defs/Receiver.hpp>
 
 namespace core
 {

--- a/source/definitions/README.md
+++ b/source/definitions/README.md
@@ -10,7 +10,7 @@ Here are presents defintions and interfaces used in the proect.
 
 ## [MDS general purpose interfaces](./include/defs/MdsInterface.hpp)
 
-## [Measurement object specific interfaces](./include/defs/MiniObjectDefs.hpp)
+## [Measurement object specific interfaces](./include/defs/MeasurementObjectDefs.hpp)
 
 ## [Receiver interfaces](./include/defs/Receiver.hpp)
 

--- a/source/definitions/include/defs/Configuration.hpp
+++ b/source/definitions/include/defs/Configuration.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <string>
+#include <cstdint>
+#include <filesystem>
+/*!
+*   @brief Interface used to load a configurarion file.
+*/
+struct ConfigurationParser
+{
+    /*!
+    *   @brief loads all the objects with their properties into the configuration manager.
+    *   @param path path to the configuration file. The full path must be provided.
+    *   @return Return a const list of measurement objects.
+    *   @note When loading a configuration, engine will be reseted and reinitialized.
+    */
+    virtual const MeasurementObjectList& loadConfiguration(std::filesystem::path path) = 0;
+    virtual bool createMeasurementObject(const std::string& name, uint8_t instanceNb) = 0;
+    /*!
+    *   @brief Method used to introduce an already created measurement object into the configuration manager.
+    *   @param object Already created measurement object that will be inserted into the configuration manager.
+    *   @return Return true if the object was inserted correctly, false otherwise.
+    */
+    virtual bool createMeasurementObject(MeasurementObjectPtr object) = 0;
+
+    /*!
+    *   @brief Method used to remove a measurement object from the configuration manager.
+    *   @param name Measurement object name
+    *   @return True if the 
+    */
+    virtual bool removeMeasurementObject(const std::string& name) = 0;
+
+    /*!
+    *   @brief Retreive the active measurement object lists from the configuration manager.
+    *   @return Return a const reference of the measurement object list.
+    */
+    virtual const MeasurementObjectList& getMOsAddedInConfig() = 0;
+
+    /*!
+    *   @brief Get the factory size. The factory size represents the number of unique measurement
+    * objects that can be created. The factory is populated using dlopen methods.
+    *   @return Return the factory size.
+    *   @note For more information about the factory read MeasurementObjectFactory class definitions.
+    */
+    virtual size_t getFactorySize() = 0;
+};

--- a/source/definitions/include/defs/DataPackage.hpp
+++ b/source/definitions/include/defs/DataPackage.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+
+enum class PackageType : uint8_t
+{
+    dummy = 0x00,
+    camera = 0x01,
+    can = 0x02,
+    flexray = 0x04,
+    ethernet = 0x08
+};
+/*!
+*   @brief Data package definition
+*/
+struct DataPackage
+{
+    uint64_t timestamp; //!< package timestamp
+    uint64_t sourceHandle; //!< package source handle
+    size_t size; //!< package size
+    uint8_t cycle_; //!< package cycle
+    PackageType type; //!< package type
+    void* payload; //!< pointer to where the package payload starts.
+};
+//! Data package pointer
+using DataPackagePtr = std::shared_ptr<DataPackage>;
+//! Const data package pointer
+using DataPackageCPtr = std::shared_ptr<const DataPackage>;

--- a/source/definitions/include/defs/Distribution.hpp
+++ b/source/definitions/include/defs/Distribution.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <defs/MiniObjectDefs.hpp>
+#include <defs/DataPackage.hpp>
 /*!
 *   @brief Data distribution interface. Let distribute a package to all linked the receivers.
 */
@@ -14,4 +14,5 @@ struct DataDistribution
     virtual bool distributeData(DataPackageCPtr package) = 0;
 };
 
+//! Data distribution pointer
 using DataDistributionPtr = std::shared_ptr<DataDistribution>;

--- a/source/definitions/include/defs/MdsInterface.hpp
+++ b/source/definitions/include/defs/MdsInterface.hpp
@@ -1,6 +1,5 @@
 #pragma once
-#include <defs/MiniObjectDefs.hpp>
-#include <filesystem>
+#include <defs/MeasurementObjectDefs.hpp>
 #include <string>
 
 /*!
@@ -42,48 +41,6 @@ enum class EngineInitFlag : uint8_t
     no_metrics = 0x02, //!< engine won't create a watchdog.
     no_exception_handler = 0x04, //!< some safety casts will be ignored.
     performance = 0x07, //!< engine will run with the following flags: silent | no_metrics | no_exception_handler
-};
-
-/*!
-*   @brief Interface used to load a configurarion file.
-*/
-struct ConfigurationParser
-{
-    /*!
-    *   @brief loads all the objects with their properties into the configuration manager.
-    *   @param path path to the configuration file. The full path must be provided.
-    *   @return Return a const list of measurement objects.
-    *   @note When loading a configuration, engine will be reseted and reinitialized.
-    */
-    virtual const MeasurementObjectList& loadConfiguration(std::filesystem::path path) = 0;
-    virtual bool createMeasurementObject(const std::string& name, uint8_t instanceNb) = 0;
-    /*!
-    *   @brief Method used to introduce an already created measurement object into the configuration manager.
-    *   @param object Already created measurement object that will be inserted into the configuration manager.
-    *   @return Return true if the object was inserted correctly, false otherwise.
-    */
-    virtual bool createMeasurementObject(MeasurementObjectPtr object) = 0;
-
-    /*!
-    *   @brief Method used to remove a measurement object from the configuration manager.
-    *   @param name Measurement object name
-    *   @return True if the 
-    */
-    virtual bool removeMeasurementObject(const std::string& name) = 0;
-
-    /*!
-    *   @brief Retreive the active measurement object lists from the configuration manager.
-    *   @return Return a const reference of the measurement object list.
-    */
-    virtual const MeasurementObjectList& getMOsAddedInConfig() = 0;
-
-    /*!
-    *   @brief Get the factory size. The factory size represents the number of unique measurement
-    * objects that can be created. The factory is populated using dlopen methods.
-    *   @return Return the factory size.
-    *   @note For more information about the factory read MeasurementObjectFactory class definitions.
-    */
-    virtual size_t getFactorySize() = 0;
 };
 
 /***************************************

--- a/source/definitions/include/defs/MeasurementObjectDefs.hpp
+++ b/source/definitions/include/defs/MeasurementObjectDefs.hpp
@@ -49,66 +49,6 @@ using MeasurementObjectPtr = std::shared_ptr<MeasurementObject>;
 //! List of measurement objects
 using MeasurementObjectList = std::list<std::shared_ptr<MeasurementObject>>;
 
-enum class PackageType : uint8_t
-{
-    dummy = 0x00,
-    camera = 0x01,
-    can = 0x02,
-    flexray = 0x04,
-    ethernet = 0x08
-};
-/*!
-*   @brief Data package definition
-*/
-struct DataPackage
-{
-    uint64_t timestamp; //!< package timestamp
-    uint64_t sourceHandle; //!< package source handle
-    size_t size; //!< package size
-    uint8_t cycle_; //!< package cycle
-    PackageType type; //!< package type
-    void* payload; //!< pointer to where the package payload starts.
-};
-//! Data package pointer
-using DataPackagePtr = std::shared_ptr<DataPackage>;
-//! Const data package pointer
-using DataPackageCPtr = std::shared_ptr<const DataPackage>;
-
-/*!
-*   @brief Interface used by any processor in order to receive packages from the distribution manager
-*/
-struct DataReceiverObject
-{
-    /*!
-    *   @brief Process data package.
-    *   @note The package cannot be altered, but a new package can be created to be delivered to the subscribers
-    *   @param package Pointer to a const data package that will be analyzed and proccessed.
-    *   @return Return true if all the processors validate the package, false if any proccesor cannot validate it.
-    */
-    virtual bool validatePackage(DataPackageCPtr package) = 0;
-};
-
-//! Data processor pointer
-using DataReceiverObjectPtr = std::shared_ptr<DataReceiverObject>;
-
-/*!
-*   @brief Interface used by any data transmitter in order to transmit packages to the distribution manager
-*/
-struct DataSenderObject
-{
-    /*!
-    *   @brief start the processing threah that will distribute data to the data distribution manager
-    */
-    virtual void startProcessing() = 0;
-    /*!
-    *   @brief end the processing threah that will distribute data to the data distribution manager
-    */
-    virtual void endProcessing() = 0;
-};
-
-//! Data transmitter pointer
-using DataSenderObjectPtr = std::shared_ptr<DataSenderObject>;
-
 using PropertyTable = std::map<std::string, std::string>;
 using PropertyPair= std::pair<std::string, std::string>;
 

--- a/source/definitions/include/defs/Receiver.hpp
+++ b/source/definitions/include/defs/Receiver.hpp
@@ -1,6 +1,23 @@
 #pragma once
 #include <cstdint>
-#include <defs/MiniObjectDefs.hpp>
+#include <defs/DataPackage.hpp>
+
+/*!
+*   @brief Interface used by any processor in order to receive packages from the distribution manager
+*/
+struct DataReceiverObject
+{
+    /*!
+    *   @brief Process data package.
+    *   @note The package cannot be altered, but a new package can be created to be delivered to the subscribers
+    *   @param package Pointer to a const data package that will be analyzed and proccessed.
+    *   @return Return true if all the processors validate the package, false if any proccesor cannot validate it.
+    */
+    virtual bool validatePackage(DataPackageCPtr package) = 0;
+};
+
+//! Data processor pointer
+using DataReceiverObjectPtr = std::shared_ptr<DataReceiverObject>;
 
 /*!
 *   @brief Interface used to notify all the subject registered using registerToReceiverSink method to a processor

--- a/source/definitions/include/defs/Transmitter.hpp
+++ b/source/definitions/include/defs/Transmitter.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+/*!
+*   @brief Interface used by any data transmitter in order to transmit packages to the distribution manager
+*/
+struct DataSenderObject
+{
+    /*!
+    *   @brief start the processing threah that will distribute data to the data distribution manager
+    */
+    virtual void startProcessing() = 0;
+    /*!
+    *   @brief end the processing threah that will distribute data to the data distribution manager
+    */
+    virtual void endProcessing() = 0;
+};
+//! Data transmitter pointer
+using DataSenderObjectPtr = std::shared_ptr<DataSenderObject>;

--- a/source/processors/raw_processor/include/RawDataProcessor.hpp
+++ b/source/processors/raw_processor/include/RawDataProcessor.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <visibility.h>
 #include <defs/MdsInterface.hpp>
-#include <defs/MiniObjectDefs.hpp>
+#include <defs/MeasurementObjectDefs.hpp>
 #include <defs/Receiver.hpp>
 #include <set>
 

--- a/source/replay/include/PlayerDefs.hpp
+++ b/source/replay/include/PlayerDefs.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <cstdint>
-#include <defs/MiniObjectDefs.hpp>
+#include <defs/DataPackage.hpp>
 
 enum class Direction
 {

--- a/source/replay/include/replay/PlayerObject.hpp
+++ b/source/replay/include/replay/PlayerObject.hpp
@@ -5,7 +5,7 @@
 
 // Core headers
 #include <defs/MdsInterface.hpp>
-#include <defs/MiniObjectDefs.hpp>
+#include <defs/MeasurementObjectDefs.hpp>
 
 // Replay headers
 #include <PlayerDefs.hpp>

--- a/source/transmitters/camera/include/transmitters/CameraObject.hpp
+++ b/source/transmitters/camera/include/transmitters/CameraObject.hpp
@@ -8,6 +8,7 @@
 #include <mutex>
 
 #include <transmitters/CameraProcessor.hpp>
+#include <defs/Transmitter.hpp>
 
 namespace transmitters
 {

--- a/source/transmitters/camera/include/transmitters/CameraProcessor.hpp
+++ b/source/transmitters/camera/include/transmitters/CameraProcessor.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <defs/MiniObjectDefs.hpp>
+#include <defs/DataPackage.hpp>
 #include <queue>
 #include <functional>
 namespace transmitters

--- a/source/transmitters/dummy/include/transmitters/DummyObject.hpp
+++ b/source/transmitters/dummy/include/transmitters/DummyObject.hpp
@@ -4,6 +4,7 @@
 #include <defs/Distribution.hpp>
 #include <memory>
 #include <defs/Distribution.hpp>
+#include <defs/Transmitter.hpp>
 #include <thread>
 #include <mutex>
 


### PR DESCRIPTION
Interfaces were separated. This resulted into smaller include files and more ease to find the desired interface.